### PR TITLE
Improve Safari font appearance + text readability

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -4,6 +4,10 @@
 @tailwind components;
 @tailwind utilities;
 
+.stat-value {
+    @apply font-semibold
+}
+
 .ct {
     @apply max-w-screen-xl mx-auto container
 }

--- a/src/components/MatchCard.svelte
+++ b/src/components/MatchCard.svelte
@@ -75,7 +75,7 @@
 					</p>
 					{#if match.bettypes[active_bettype_index].no_risk.possible}
 						{#each match.bettypes[active_bettype_index].no_risk.bet as { team, amount }}
-							<p><b>{team}:</b> Bet <span class="badge">{amount}</span> tokens</p>
+							<p><span class="font-semibold">{team}:</span> Bet <span class="badge">{amount}</span> tokens</p>
 						{/each}
 					{:else}
 						sorry, not possible

--- a/src/components/MatchDisplay.svelte
+++ b/src/components/MatchDisplay.svelte
@@ -174,7 +174,7 @@
 					<h2 class="card-title">Sort by</h2>
 					<div class="card-actions justify-end">
 						<div class="form-control w-full max-w-xs">
-							<select class="select select-bordered" bind:value={sort} aria-label="Sort by">
+							<select class="select select-bordered font-normal" bind:value={sort} aria-label="Sort by">
 								<option value="-max_no_risk_profit_sb_percentage">No Risk Profit - Desc</option>
 								<option value="max_no_risk_profit_sb_percentage">No Risk Profit - Asc</option>
 								<option value="-cutoff_datetime">Cutoff Time - Desc</option>
@@ -211,7 +211,7 @@
 							<label class="label">
 								<span class="label-text ">Filter by sport</span>
 							</label>
-							<select class="select select-bordered" bind:value={sport}>
+							<select class="select select-bordered font-normal" bind:value={sport}>
 								<option disabled selected>Pick one</option>
 								{#each sports as sport}
 									<option>{sport}</option>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,5 +1,10 @@
 <script>
-	import '@fontsource/inter';
+	import '@fontsource/inter/300.css';
+	import '@fontsource/inter/400.css';
+	import '@fontsource/inter/500.css';
+	import '@fontsource/inter/700.css';
+	import '@fontsource/inter/800.css';
+
 	import '../app.css';
 	import { darkmode, title } from '../stores';
 	import { onMount } from 'svelte';

--- a/src/routes/match/[uuid].svelte
+++ b/src/routes/match/[uuid].svelte
@@ -189,7 +189,7 @@
 										<div>
 											<p class="opacity-90">{team}</p>
 											<p class="text-2xl font-bold">
-												Bet <span class="font-extrabold">{amount}</span> tokens
+												Bet <span class="font-bold">{amount}</span> tokens
 											</p>
 										</div>
 										<!-- don't display this one if it's the last bet (i.e. check if index is equal to length -1) -->


### PR DESCRIPTION
Safari has weird quirks with font display when font weights aren't explicitly imported (see https://github.com/unixfy/unixfy.net/pull/11 for example). This issue is resolved in this PR.
Also, font weights were adjusted to look nicer and be more readable. :)